### PR TITLE
Feature 5 Endless wait at KexManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .gradle
 build
+.idea
+gradlew
+gradlew.bat
+gradle

--- a/src/main/java/ch/ethz/ssh2/Connection.java
+++ b/src/main/java/ch/ethz/ssh2/Connection.java
@@ -756,7 +756,7 @@ public class Connection {
 
 			/* Wait until first KEX has finished */
 
-            ConnectionInfo ci = tm.getConnectionInfo(1);
+            ConnectionInfo ci = tm.getConnectionInfo(1, connectTimeout);
 
 			/* Now try to cancel the timeout, if needed */
 
@@ -926,7 +926,7 @@ public class Connection {
     public synchronized ConnectionInfo getConnectionInfo() throws IOException {
         this.checkConnection();
 
-        return tm.getConnectionInfo(1);
+        return tm.getConnectionInfo(1, 0);
     }
 
     /**

--- a/src/main/java/ch/ethz/ssh2/ServerConnection.java
+++ b/src/main/java/ch/ethz/ssh2/ServerConnection.java
@@ -133,7 +133,7 @@ public class ServerConnection
 
 		/* Wait until first KEX has finished */
 
-		state.tm.getConnectionInfo(1);
+		state.tm.getConnectionInfo(1, timeout_milliseconds);
 	}
 
 	/**
@@ -192,7 +192,7 @@ public class ServerConnection
 						"Cannot get details of connection, you need to start the key exchange first.");
 		}
 
-		return state.tm.getConnectionInfo(1);
+		return state.tm.getConnectionInfo(1, 0);
 	}
 
 	/**

--- a/src/main/java/ch/ethz/ssh2/transport/KexManager.java
+++ b/src/main/java/ch/ethz/ssh2/transport/KexManager.java
@@ -63,7 +63,7 @@ public abstract class KexManager implements MessageHandler
 		this.rnd = rnd;
 	}
 
-	public ConnectionInfo getOrWaitForConnectionInfo(int minKexCount) throws IOException
+	public ConnectionInfo getOrWaitForConnectionInfo(int minKexCount, int timeoutMs) throws IOException
 	{
         synchronized (accessLock)
         {
@@ -77,7 +77,7 @@ public abstract class KexManager implements MessageHandler
 
                 try
                 {
-                    accessLock.wait();
+                    accessLock.wait(timeoutMs);
                 }
                 catch (InterruptedException e)
                 {

--- a/src/main/java/ch/ethz/ssh2/transport/TransportManager.java
+++ b/src/main/java/ch/ethz/ssh2/transport/TransportManager.java
@@ -165,8 +165,8 @@ public abstract class TransportManager {
         return tc.getPacketOverheadEstimate();
     }
 
-    public ConnectionInfo getConnectionInfo(int kexNumber) throws IOException {
-        return km.getOrWaitForConnectionInfo(kexNumber);
+    public ConnectionInfo getConnectionInfo(int kexNumber, int timeoutMs) throws IOException {
+        return km.getOrWaitForConnectionInfo(kexNumber, timeoutMs);
     }
 
     public Throwable getReasonClosedCause() {


### PR DESCRIPTION
Use socket connection at kex manager wait.
It allows to limit waiting without creation of new thread (if use kex timeout). 